### PR TITLE
Update backstage provider and README for backstage new backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,41 @@ backend:
 catalog:
   rules:
     - allow: [Domain, System, Component, API, Location, Template, User, Group]
+  providers:
+# Give some configuration to the Vela Entity Provider
+    vela:
+      host: http://backstage-plugin-vela.vela-system:8080 # Change this to the endpoint of the connector
+      schedule: #optional section
+        initialDelay: { seconds: 30 }
+        # frequency is the refresh rate for the Vela API, defaults to 60 seconds
+        frequency: { hours: 30 }
+        # timeout is the timeout limit for the Vela API, defaults to 600 seconds
+        timeout: { minutes: 2 }
+```
+
+Configure Backstage to use the Vela Entity Provider with the new backend
+
+```diff
+ // packages/backend/src/index.ts
++import { VelaProvideriModule } from '@oamdev/plugin-kubevela-backend';
++backend.add(velaProviderModule);
+```
+
+#### configuring backstage with the older backend
+
+```yaml
+# Merge the following lines into your app-config.yaml
+backend:
+  reading:
+    allow:
+      - host: backstage-plugin-vela.vela-system:8080 # Required, change this to the endpoint of the connector
+      - host: raw.githubusercontent.com # Optional
+      - host: kubevela.io # Optional
+      - host: kubevela.net # Optional
+
+catalog:
+  rules:
+    - allow: [Domain, System, Component, API, Location, Template, User, Group]
 
 # Give some configuration to the Vela Entity Provider
 vela:
@@ -195,7 +230,7 @@ Configure Backstage to use the Vela Entity Provider
  }
 ```
 
-Optional step: add VelaUX page to sidebar
+### Optional step: add VelaUX page to sidebar
 
 ```diff
  // packages/app/src/components/Root/Root.tsx

--- a/src/providers/VelaProviderModule.ts
+++ b/src/providers/VelaProviderModule.ts
@@ -1,0 +1,39 @@
+import {
+  coreServices,
+  createBackendModule,
+  SchedulerServiceTaskScheduleDefinition,
+  readSchedulerServiceTaskScheduleDefinitionFromConfig,
+} from '@backstage/backend-plugin-api';
+import { VelaProvider } from './VelaProvider';
+
+export const velaProviderModule = createBackendModule({
+  pluginId: 'catalog',
+  moduleId: 'vela-provider',
+  register(env) {
+    env.registerInit({
+      deps: {
+        catalog: catalogProcessingExtensionPoint,
+        reader: coreServices.urlReader,
+        scheduler: coreServices.scheduler,
+        rootConfig: coreServices.rootConfig
+      },
+      async init({ catalog, reader, scheduler, rootConfig }) {
+        const config = rootConfig.getConfig('catalog.providers.vela')
+        const frequency: number = config.getOptionalNumber('frequency') || 60;
+        const timeout: number = config.getOptionalNumber('timeout') || 600;
+        const hostname:string = config.getConfig('host');
+        const schedule = config.has('schedule')
+          ? readSchedulerServiceTaskScheduleDefinitionFromConfig(
+              config.getConfig('schedule'),
+            )
+          : {
+              frequency: { seconds: 60 },
+              timeout: { seconds: 600 },
+            };
+        const taskRunner = scheduler.createScheduledTaskRunner(schedule);
+        const vela = new VelaProvider('dev', reader, taskRunner, hostname);
+        catalog.addEntityProvider(vela);
+      },
+    });
+  },
+});


### PR DESCRIPTION
Addresses at least part of Issue #8 

Allows the backstage Entity Provider plugin to be used with the new backstage backend.

It will separately need to be confirmed if the demo backstage instance install done as part of `vela addon enable backstage` (without `--pluginOnly`) needs to be updated.

Obviously this needs to be tested once it's been built and published as `@oamdev/plugin-kubevela-backend` but with adjusted include path in index.ts, it has worked on my local latest backstage instance with `VelaProvider.ts` and `VelaProviderModule.ts` copied into the plugins dir.

FYI @wonderflow 